### PR TITLE
fix: update supplier validation rules to ignore current supplier

### DIFF
--- a/app/Http/Requests/Suppliers/UpdateSupplierRequest.php
+++ b/app/Http/Requests/Suppliers/UpdateSupplierRequest.php
@@ -4,6 +4,7 @@ namespace App\Http\Requests\Suppliers;
 
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Validation\Rule;
 
 class UpdateSupplierRequest extends FormRequest
 {
@@ -23,8 +24,16 @@ class UpdateSupplierRequest extends FormRequest
     public function rules(): array
     {
         return [
-            'name' => [ 'string', 'max:255', 'unique:suppliers'],
-            'email' => [ 'email', 'max:255', 'unique:suppliers'],
+            'name' => [
+                'string',
+                'max:255',
+                Rule::unique('suppliers')->ignore($this->route('supplier')->id)
+            ],
+            'email' => [
+                'email',
+                'max:255',
+                Rule::unique('suppliers')->ignore($this->route('supplier')->id)
+            ],
             'phone' => [ 'string', 'max:20'],
             'address' => [ 'string', 'max:255'],
             'zipcode' => [ 'string', 'max:5'],


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue in the supplier update process so that existing names and emails are no longer mistakenly flagged as duplicates. Users can now update supplier details without encountering unnecessary validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->