### PR TITLE
Add order status validation and update endpoint

### DIFF
--- a/app/Http/Controllers/OrdersController.php
+++ b/app/Http/Controllers/OrdersController.php
@@ -203,7 +203,23 @@ class OrdersController
      */
     public function update(Request $request, Order $order)
     {
-        //
+        if (Auth::user()->role !== Role::ADMIN &&
+            Auth::user()->role !== Role::GESTIONNAIRE) {
+            return response()->json([
+                'message' => 'Unauthorized',
+            ], 403);
+        }
+
+        $validated = $request->validate([
+            'status' => 'required|in:' . implode(',', Order::STATUS_VALUES),
+        ]);
+
+        $order->update($validated);
+
+        return response()->json([
+            'message' => 'Order updated successfully',
+            'data' => new OrderResource($order),
+        ], 200);
     }
 
     /**

--- a/app/Models/Order.php
+++ b/app/Models/Order.php
@@ -9,14 +9,24 @@ use Illuminate\Support\Facades\App;
 
 class Order extends Model
 {
+
     const STATUS_PENDING = 'pending';
     const STATUS_PROCESSING = 'processing';
     const STATUS_COMPLETED = 'completed';
     const STATUS_CANCELLED = 'cancelled';
     const STATUS_SHIPPED = 'shipped';
 
+    const STATUS_VALUES = [
+        self::STATUS_PENDING,
+        self::STATUS_PROCESSING,
+        self::STATUS_COMPLETED,
+        self::STATUS_CANCELLED,
+        self::STATUS_SHIPPED,
+    ];
+
     /** VAT rate (20 %) – falls back to env/config value */
     public const TAX_RATE = 0.20; // <- fallback only
+
 
     protected $fillable = [
         'user_id',

--- a/routes/api.php
+++ b/routes/api.php
@@ -45,6 +45,9 @@ Route::group(['middleware' => ['auth:api']], function () {
 
         //ROLES
         Route::apiResource('/roles', RolesController::class);
+
+        //COMMANDS
+        Route::apiResource('/orders', OrdersController::class)->only(['update']);
     });
 
     //Admin and Gestionnaire routes


### PR DESCRIPTION
Introduced status validation in `OrdersController` to enforce allowed statuses, using `Order::STATUS_VALUES`. Added `update` method with role-based access control and proper response handling. Registered the `update` endpoint in API routes.